### PR TITLE
add missing semicolon on use line in test

### DIFF
--- a/t/02-mutate.t
+++ b/t/02-mutate.t
@@ -4,7 +4,7 @@ use warnings;
 use Test::Most;
 plan qw/no_plan/;
 
-use MooseX::MakeImmutable
+use MooseX::MakeImmutable;
 
 MooseX::MakeImmutable->make_immutable(<<_END_);
 t::Test::Alpha


### PR DESCRIPTION
Without a semicolon, the output of the following command would be used as an argument to the module's import method. In the past this was ignored, but future versions of perl are intending to make it an error to pass arguments to an undefined import method.